### PR TITLE
Remove redundant check for c5 slice being empty

### DIFF
--- a/contracts/wallet_v5.fc
+++ b/contracts/wallet_v5.fc
@@ -85,7 +85,6 @@ cell verify_c5_actions(cell c5, int is_external) inline {
     count += 1;
   }
   throw_unless(error::invalid_c5, count <= 255);
-  throw_unless(error::invalid_c5, cs.slice_refs() == 0);
 
   return c5;
 }
@@ -202,7 +201,7 @@ cell verify_c5_actions(cell c5, int is_external) inline {
     .end_cell());
 
   if (is_external) {
-    ;; For external messages we commit seqno changes, so that even if an exception occurs further on, the reply-protection will still work.
+    ;; For external messages we commit seqno changes, so that even if an exception occurs further on, the replay-protection will still work.
     commit();
   }
 

--- a/types.tlb
+++ b/types.tlb
@@ -23,7 +23,7 @@ internal_signed#73696e74 signed:SignedRequest = InternalMsgBody;
 internal_extension#6578746e query_id:(## 64) inner:InnerRequest = InternalMsgBody;
 external_signed#7369676e signed:SignedRequest = ExternalMsgBody;
 
-actions$_ out_actions:(Maybe OutList) has_other_actions:(## 1) {m:#} {n:#} other_actions:(ActionList n m) = InnerRequest;
+actions$_ out_actions:(Maybe ^OutList) has_other_actions:(## 1) {m:#} {n:#} other_actions:(ActionList n m) = InnerRequest;
 
 // Contract state
 contract_state$_ is_signature_allowed:(## 1) seqno:# wallet_id:(## 32) public_key:(## 256) extensions_dict:(HashmapE 256 int1) = ContractState;


### PR DESCRIPTION
Hey,

The check for the slice refs being zero is redundant and can be safely removed, since in the previous loop the slice is checked to be not empty.

Also, a small typo in comments is fixed (replay-protection).

And I think `OutList` should be a ref in TLB file.