### PR TITLE
Fix TLB to match the separation of extended actions

### DIFF
--- a/types.tlb
+++ b/types.tlb
@@ -4,12 +4,15 @@ out_list$_ {n:#} prev:^(OutList n) action:OutAction = OutList (n + 1);
 action_send_msg#0ec3c86d mode:(## 8) out_msg:^(MessageRelaxed Any) = OutAction;
 
 // Extended actions in W5:
-action_list_basic$_ {n:#} actions:^(OutList n) = ActionList n 0;
-action_list_extended$_ {m:#} {n:#} action:ExtendedAction prev:^(ActionList n m) = ActionList n (m+1);
+action_list_none$_ = ActionList 0;
+action_list_last$_ action:ExtendedAction = ActionList 1;
+action_list_more$_ {m > 1} action:ExtendedAction prev:^(ActionList m) = ActionList (m+1);
 
 action_add_ext#02 addr:MsgAddressInt = ExtendedAction;
 action_delete_ext#03 addr:MsgAddressInt = ExtendedAction;
 action_set_signature_auth_allowed#04 allowed:(## 1) = ExtendedAction;
+
+actions$_ {n:#} out_actions:(Maybe ^(OutList n)) has_other_actions:(## 1) {m:#} other_actions:(ActionList m) = InnerRequest;
 
 signed_request$_             // 32 (opcode from outer)
   wallet_id:    #            // 32
@@ -19,11 +22,9 @@ signed_request$_             // 32 (opcode from outer)
   signature:    bits512      // 512
 = SignedRequest;             // Total: 688 .. 976 + ^Cell
 
+external_signed#7369676e signed:SignedRequest = ExternalMsgBody;
 internal_signed#73696e74 signed:SignedRequest = InternalMsgBody;
 internal_extension#6578746e query_id:(## 64) inner:InnerRequest = InternalMsgBody;
-external_signed#7369676e signed:SignedRequest = ExternalMsgBody;
-
-actions$_ out_actions:(Maybe OutList) has_other_actions:(## 1) {m:#} {n:#} other_actions:(ActionList n m) = InnerRequest;
 
 // Contract state
 contract_state$_ is_signature_allowed:(## 1) seqno:# wallet_id:(## 32) public_key:(## 256) extensions_dict:(HashmapE 256 int1) = ContractState;

--- a/types.tlb
+++ b/types.tlb
@@ -4,15 +4,15 @@ out_list$_ {n:#} prev:^(OutList n) action:OutAction = OutList (n + 1);
 action_send_msg#0ec3c86d mode:(## 8) out_msg:^(MessageRelaxed Any) = OutAction;
 
 // Extended actions in W5:
-action_list_none$_ = ActionList 0;
-action_list_last$_ action:ExtendedAction = ActionList 1;
+action_list_empty$_ = ActionList 0;
+action_list_one$_ action:ExtendedAction = ActionList 1;
 action_list_more$_ {m > 1} action:ExtendedAction prev:^(ActionList m) = ActionList (m+1);
 
 action_add_ext#02 addr:MsgAddressInt = ExtendedAction;
 action_delete_ext#03 addr:MsgAddressInt = ExtendedAction;
 action_set_signature_auth_allowed#04 allowed:(## 1) = ExtendedAction;
 
-actions$_ {n:#} out_actions:(Maybe ^(OutList n)) has_other_actions:(## 1) {m:#} other_actions:(ActionList m) = InnerRequest;
+actions$_ {n:#} out_actions:(Maybe ^(OutList n)) {m:#} has_other_actions:(Maybe (ActionList m)) = InnerRequest;
 
 signed_request$_             // 32 (opcode from outer)
   wallet_id:    #            // 32

--- a/types.tlb
+++ b/types.tlb
@@ -6,7 +6,7 @@ action_send_msg#0ec3c86d mode:(## 8) out_msg:^(MessageRelaxed Any) = OutAction;
 // Extended actions in W5:
 action_list_empty$_ = ActionList 0;
 action_list_one$_ action:ExtendedAction = ActionList 1;
-action_list_more$_ {m > 1} action:ExtendedAction prev:^(ActionList m) = ActionList (m+1);
+action_list_more$_ {m >= 1} action:ExtendedAction prev:^(ActionList m) = ActionList (m+1);
 
 action_add_ext#02 addr:MsgAddressInt = ExtendedAction;
 action_delete_ext#03 addr:MsgAddressInt = ExtendedAction;


### PR DESCRIPTION
Wallet extended actions were previously put before the normal actions. In the new design, they are separated, which I think is more streamlined. However, the TLB does not match the code, because it still allows normal actions to be defined inside extended actions, which makes the code to throw an exception in this case.

This new version of TLB tries to improve this, so that anyone reading the TLB has better understanding of how should the structure of the messages be.